### PR TITLE
Add parameterized tests

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsReplacerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsReplacerTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,25 @@ class AuthorAndsReplacerTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorAndsReplacer#format(java.lang.String)}.
      */
-    @Test
-    void format() {
+    @ParameterizedTest
+    @CsvSource({
+            // Empty case
+            "'', ''",
+
+            // Single name (unchanged)
+            "'Someone, Van Something', 'Someone, Van Something'",
+
+            // 'and' replaced with '&' in two names
+            "'John Smith and Black Brown, Peter', 'John Smith & Black Brown, Peter'",
+
+            // 'and' replaced with ';' and '&' for three names
+            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, John; Smith, John & Black Brown, Peter'",
+
+            // 'and' replaced with ';' and '&' for three names
+            "'John von Neumann and John Smith and Peter Black Brown', 'John von Neumann; John Smith & Peter Black Brown'"
+    })
+    void format(String input, String expected) {
         LayoutFormatter a = new AuthorAndsReplacer();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names don't change
-        assertEquals("Someone, Van Something", a.format("Someone, Van Something"));
-
-        // Two names just an &
-        assertEquals("John Smith & Black Brown, Peter", a
-                .format("John Smith and Black Brown, Peter"));
-
-        // Three names put a comma:
-        assertEquals("von Neumann, John; Smith, John & Black Brown, Peter", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("John von Neumann; John Smith & Peter Black Brown", a
-                .format("John von Neumann and John Smith and Peter Black Brown"));
+        assertEquals(expected, a.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommasTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,23 @@ class AuthorFirstLastOxfordCommasTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorFirstLastOxfordCommas#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorFirstLastOxfordCommas();
+    @ParameterizedTest
+    @CsvSource({
+            // Empty case
+            "'', ''",
 
-        // Empty case
-        assertEquals("", a.format(""));
+            // Single Names
+            "'Someone, Van Something', Van Something Someone",
 
-        // Single Names
-        assertEquals("Van Something Someone", a.format("Someone, Van Something"));
+            // Two names
+            "John von Neumann and Peter Black Brown, John von Neumann and Peter Black Brown",
 
-        // Two names
-        assertEquals("John von Neumann and Peter Black Brown", a
-                .format("John von Neumann and Peter Black Brown"));
-
-        // Three names
-        assertEquals("John von Neumann, John Smith, and Peter Black Brown", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("John von Neumann, John Smith, and Peter Black Brown", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+            // Three names
+            "'von Neumann, John and Smith, John and Black Brown, Peter', 'John von Neumann, John Smith, and Peter Black Brown'",
+            "'John von Neumann and John Smith and Black Brown, Peter', 'John von Neumann, John Smith, and Peter Black Brown'"
+    })
+    void format(String input, String expected) {
+        LayoutFormatter formatter = new AuthorFirstLastOxfordCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommasTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,23 @@ class AuthorLastFirstAbbrOxfordCommasTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstAbbrOxfordCommas#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorLastFirstAbbrOxfordCommas();
+    @ParameterizedTest
+    @CsvSource({
+            // Empty case
+            "'', ''",
 
-        // Empty case
-        assertEquals("", a.format(""));
+            // Single Names
+            "Van Something Someone, 'Someone, V. S.'",
 
-        // Single Names
-        assertEquals("Someone, V. S.", a.format("Van Something Someone"));
+            // Two names
+            "'John von Neumann and Black Brown, Peter', 'von Neumann, J. and Black Brown, P.'",
 
-        // Two names
-        assertEquals("von Neumann, J. and Black Brown, P.", a
-                .format("John von Neumann and Black Brown, Peter"));
-
-        // Three names
-        assertEquals("von Neumann, J., Smith, J., and Black Brown, P.", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("von Neumann, J., Smith, J., and Black Brown, P.", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+            // Three names
+            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, J., Smith, J., and Black Brown, P.'",
+            "'John von Neumann and John Smith and Black Brown, Peter', 'von Neumann, J., Smith, J., and Black Brown, P.'"
+    })
+    void format(String input, String expected) {
+        LayoutFormatter formatter = new AuthorLastFirstAbbrOxfordCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTest.java
@@ -1,62 +1,41 @@
 package org.jabref.logic.layout.format;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/**
- * Test case  that verifies the functionalities of the formater AuthorLastFirstAbbreviator.
- */
 class AuthorLastFirstAbbreviatorTest {
 
-    /**
-     * Verifies the Abbreviation of one single author with a simple name.
-     * <p/>
-     * Ex: Lastname, Name
-     */
-    @Test
-    void oneAuthorSimpleName() {
-        assertEquals("Lastname, N.", abbreviate("Lastname, Name"));
-    }
+    private final AuthorLastFirstAbbreviator abbreviator = new AuthorLastFirstAbbreviator();
 
-    /**
-     * Verifies the Abbreviation of one single author with a common name.
-     * <p/>
-     * Ex: Lastname, Name Middlename
-     */
-    @Test
-    void oneAuthorCommonName() {
-        assertEquals("Lastname, N. M.", abbreviate("Lastname, Name Middlename"));
-    }
+    @ParameterizedTest
+    @CsvSource({
+            // One author, simple name
+            "'Lastname, Name', 'Lastname, N.'",
 
-    /**
-     * Verifies the Abbreviation of two single with a common name.
-     * <p/>
-     * Ex: Lastname, Name Middlename
-     */
-    @Test
-    void twoAuthorsCommonName() {
-        String result = abbreviate("Lastname, Name Middlename and Sobrenome, Nome Nomedomeio");
-        String expectedResult = "Lastname, N. M. and Sobrenome, N. N.";
+            // One author, common name with middle name
+            "'Lastname, Name Middlename', 'Lastname, N. M.'",
 
-        assertEquals(expectedResult, result);
-    }
+            // Two authors with common names
+            "'Lastname, Name Middlename and Sobrenome, Nome Nomedomeio', 'Lastname, N. M. and Sobrenome, N. N.'",
 
-    @Test
-    void jrAuthor() {
-        assertEquals("Other, Jr., A. N.", abbreviate("Other, Jr., Anthony N."));
-    }
+            // Author with Jr. suffix
+            "'Other, Jr., Anthony N.', 'Other, Jr., A. N.'",
 
-    @Test
-    void format() {
-        assertEquals("", abbreviate(""));
-        assertEquals("Someone, V. S.", abbreviate("Someone, Van Something"));
-        assertEquals("Smith, J.", abbreviate("Smith, John"));
-        assertEquals("von Neumann, J. and Smith, J. and Black Brown, P.",
-                abbreviate("von Neumann, John and Smith, John and Black Brown, Peter"));
-    }
+            // Empty input returns empty
+            "'', ''",
 
-    private String abbreviate(String name) {
-        return new AuthorLastFirstAbbreviator().format(name);
+            // Author with prefix like Van
+            "'Someone, Van Something', 'Someone, V. S.'",
+
+            // Single author
+            "'Smith, John', 'Smith, J.'",
+
+            // Multiple authors with complex last names
+            "'von Neumann, John and Smith, John and Black Brown, Peter', 'von Neumann, J. and Smith, J. and Black Brown, P.'"
+    })
+    void abbreviate(String input, String expected) {
+        assertEquals(expected, abbreviator.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RemoveBracketsTest.java
@@ -3,11 +3,13 @@ package org.jabref.logic.layout.format;
 import org.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class RemoveBracketsTest {
+
     private LayoutFormatter formatter;
 
     @BeforeEach
@@ -15,28 +17,27 @@ class RemoveBracketsTest {
         formatter = new RemoveBrackets();
     }
 
-    @Test
-    void bracePairCorrectlyRemoved() {
-        assertEquals("some text", formatter.format("{some text}"));
-    }
+    /**
+     * Test method for {@link org.jabref.logic.layout.format.RemoveBrackets#format(String)}.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            // Brace pair correctly removed
+            "{some text}, some text",
 
-    @Test
-    void singleOpeningBraceCorrectlyRemoved() {
-        assertEquals("some text", formatter.format("{some text"));
-    }
+            // Single opening brace correctly removed
+            "{some text, some text",
 
-    @Test
-    void singleClosingBraceCorrectlyRemoved() {
-        assertEquals("some text", formatter.format("some text}"));
-    }
+            // Single closing brace correctly removed
+            "some text}, some text",
 
-    @Test
-    void bracePairWithEscapedBackslashCorrectlyRemoved() {
-        assertEquals("\\some text\\", formatter.format("\\{some text\\}"));
-    }
+            // Brace pair with escaped backslash correctly removed
+            "'\\\\{some text\\\\}', '\\\\some text\\\\'",
 
-    @Test
-    void withoutBracketsUnmodified() {
-        assertEquals("some text", formatter.format("some text"));
+            // Without brackets unmodified
+            "some text, some text"
+    })
+    void format(String input, String expected) {
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RemoveLatexCommandsFormatterTest.java
@@ -1,7 +1,8 @@
 package org.jabref.logic.layout.format;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,48 +15,39 @@ class RemoveLatexCommandsFormatterTest {
         formatter = new RemoveLatexCommandsFormatter();
     }
 
-    @Test
-    void withoutLatexCommandsUnmodified() {
-        assertEquals("some text", formatter.format("some text"));
-    }
+    /**
+     * Test method for {@link RemoveLatexCommandsFormatter#format(String)}.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            // Without LaTeX commands
+            "some text, some text",
 
-    @Test
-    void singleCommandWiped() {
-        assertEquals("", formatter.format("\\sometext"));
-    }
+            // Single command wiped
+            "\\sometext, ''",
 
-    @Test
-    void singleSpaceAfterCommandRemoved() {
-        assertEquals("text", formatter.format("\\some text"));
-    }
+            // Single space after command removed
+            "\\some text, text",
 
-    @Test
-    void multipleSpacesAfterCommandRemoved() {
-        assertEquals("text", formatter.format("\\some     text"));
-    }
+            // Multiple spaces after command removed
+            "\\some     text, text",
 
-    @Test
-    void escapedBackslashBecomesBackslash() {
-        assertEquals("\\", formatter.format("\\\\"));
-    }
+            // Escaped backslash becomes backslash
+            "'\\\\', '\\'",
 
-    @Test
-    void escapedBackslashFollowedByTextBecomesBackslashFollowedByText() {
-        assertEquals("\\some text", formatter.format("\\\\some text"));
-    }
+            // Escaped backslash followed by text
+            "'\\\\some text', '\\some text'",
 
-    @Test
-    void escapedBackslashKept() {
-        assertEquals("\\some text\\", formatter.format("\\\\some text\\\\"));
-    }
+            // Escaped backslash kept
+            "'\\\\some text\\\\', '\\some text\\'",
 
-    @Test
-    void escapedUnderscoreReplaces() {
-        assertEquals("some_text", formatter.format("some\\_text"));
-    }
+            // Escaped underscore replaced
+            "some\\_text, some_text",
 
-    @Test
-    void exampleUrlCorrectlyCleaned() {
-        assertEquals("http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf", formatter.format("http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf"));
+            // Realistic LaTeX URL with escaped underscores
+            "'http://pi.informatik.uni-siegen.de/stt/36\\_2/./03\\_Technische\\_Beitraege/ZEUS2016/beitrag\\_2.pdf', 'http://pi.informatik.uni-siegen.de/stt/36_2/./03_Technische_Beitraege/ZEUS2016/beitrag_2.pdf'"
+    })
+    void format(String input, String expected) {
+        assertEquals(expected, formatter.format(input));
     }
 }


### PR DESCRIPTION
Closes JabRef#676

This PR refactors several unit tests in the jablib/src/test/java/org/jabref/logic/layout/format/ package to use JUnit 5 parameterized tests.
The goal is to simplify repetitive test logic, improve readability, and make future additions to formatting rules easier to maintain.

Steps to test
1. Build JabRef as usual

2. Confirm that the following tests pass:

- AuthorAndsReplacerTest.java
- AuthorFirstLastOxfordCommasTest.java
- RemoveBracketsTest.java
- RemoveLatexCommandsFormatterTest.java
- AuthorLastFirstAbbreviatorTest.java
- AuthorLastFirstAbbrOxfordCommasTest.java

3. Verify that test output and behavior are unchanged.

Mandatory checks
- [x] I own the copyright of the code submitted and I license it under the MIT license
- [ ] I manually tested my changes in running JabRef (always required)
- [x] I added JUnit tests for changes (if applicable)
[/] I added screenshots in the PR description (if change is visible to the user)
[/] I described the change in CHANGELOG.md in a way that is understandable for the average user (if change is visible to the user)
[/] I checked the user documentation: Is the information available and up to date? If not, I created an issue at https://github.com/JabRef/user-documentation/issues or, even better, I submitted a pull request updating file(s) in https://github.com/JabRef/user-documentation/tree/main/en.